### PR TITLE
Add options for different types of generated kid

### DIFF
--- a/src/main/java/org/mitre/jose/jwk/ECKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/ECKeyMaker.java
@@ -28,7 +28,7 @@ public class ECKeyMaker {
      * @param kid
      * @return
      */
-    public static ECKey make(Curve crv, KeyUse keyUse, Algorithm keyAlg, String kid) {
+    public static ECKey make(Curve crv, KeyUse keyUse, Algorithm keyAlg, KeyIdGenerator keyIdGenerator) {
 
         try {
             ECParameterSpec ecSpec = crv.toECParameterSpec();
@@ -43,7 +43,7 @@ public class ECKeyMaker {
 
             ECKey ecKey = new ECKey.Builder(crv, pub)
                     .privateKey(priv)
-                    .keyID(kid)
+                    .keyID(keyIdGenerator.generate(keyUse, kp.getPublic().getEncoded()))
                     .algorithm(keyAlg)
                     .keyUse(keyUse)
                     .build();

--- a/src/main/java/org/mitre/jose/jwk/KeyIdGenerator.java
+++ b/src/main/java/org/mitre/jose/jwk/KeyIdGenerator.java
@@ -1,0 +1,8 @@
+package org.mitre.jose.jwk;
+
+import com.nimbusds.jose.jwk.KeyUse;
+
+public interface KeyIdGenerator
+{
+  String generate(KeyUse keyUse, byte[] pubKey);
+}

--- a/src/main/java/org/mitre/jose/jwk/KeyIdType.java
+++ b/src/main/java/org/mitre/jose/jwk/KeyIdType.java
@@ -1,0 +1,53 @@
+package org.mitre.jose.jwk;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.util.Base64;
+
+/**
+ * Key ID (kid) types for generated kids.
+ */
+public enum KeyIdType implements KeyIdGenerator
+{
+  /** Key usage plus a timestamp - default */
+  UsageTimestamp
+  {
+    @Override
+    public String generate(KeyUse keyUse, byte[] pubKey)
+    {
+      String prefix = keyUse == null ? "" : keyUse.identifier();
+      return prefix + (System.currentTimeMillis() / 1000);
+    }
+  },
+
+  /** No key ID */
+  None
+  {
+    @Override
+    public String generate(KeyUse keyUse, byte[] pubKey)
+    {
+      return null;
+    }
+  },
+  
+  /** Base64 encoded SHA-1 Hash of the Public Key encoded bytes */ 
+  Sha1PubKey
+  {
+    @Override
+    public String generate(KeyUse keyUse, byte[] pubKey)
+    {
+      try
+      {
+        byte[] bytes = MessageDigest.getInstance("SHA-1").digest(pubKey);
+        
+        return Base64.encode(bytes).toString();
+      }
+      catch(NoSuchAlgorithmException e)
+      {
+        throw new IllegalStateException("SHA-1 is not a valid algorithm!", e);
+      }
+    }
+  };
+}

--- a/src/main/java/org/mitre/jose/jwk/OKPKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/OKPKeyMaker.java
@@ -29,7 +29,7 @@ public class OKPKeyMaker {
 	 * @param kid
 	 * @return
 	 */
-	public static JWK make(Curve keyCurve, KeyUse keyUse, Algorithm keyAlg, String kid) {
+	public static JWK make(Curve keyCurve, KeyUse keyUse, Algorithm keyAlg, KeyIdGenerator keyIdGenerator) {
 
 		try {
 
@@ -89,7 +89,7 @@ public class OKPKeyMaker {
 				.d(Base64URL.encode(d))
 				.keyUse(keyUse)
 				.algorithm(keyAlg)
-				.keyID(kid)
+				.keyID(keyIdGenerator.generate(keyUse, keyPair.getPublic().getEncoded()))
 				.build();
 
 			return jwk;

--- a/src/main/java/org/mitre/jose/jwk/OctetSequenceKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/OctetSequenceKeyMaker.java
@@ -19,7 +19,7 @@ public class OctetSequenceKeyMaker {
      * @param keySize in bits
      * @return
      */
-    public static OctetSequenceKey make(Integer keySize, KeyUse use, Algorithm alg, String kid) {
+    public static OctetSequenceKey make(Integer keySize, KeyUse use, Algorithm alg, KeyIdGenerator keyIdGenerator) {
 
         // holder for the random bytes
         byte[] bytes = new byte[keySize / 8];
@@ -32,7 +32,7 @@ public class OctetSequenceKeyMaker {
 
         // make a key
         OctetSequenceKey octetSequenceKey = new OctetSequenceKey.Builder(encoded)
-                .keyID(kid)
+                .keyID(keyIdGenerator.generate(use, bytes))
                 .algorithm(alg)
                 .keyUse(use)
                 .build();

--- a/src/main/java/org/mitre/jose/jwk/RSAKeyMaker.java
+++ b/src/main/java/org/mitre/jose/jwk/RSAKeyMaker.java
@@ -25,7 +25,7 @@ public class RSAKeyMaker {
      * @param kid
      * @return
      */
-    public static RSAKey make(Integer keySize, KeyUse keyUse, Algorithm keyAlg, String kid) {
+    public static RSAKey make(Integer keySize, KeyUse keyUse, Algorithm keyAlg, KeyIdGenerator keyIdGenerator) {
 
         try {
             KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
@@ -39,7 +39,7 @@ public class RSAKeyMaker {
                     .privateKey(priv)
                     .keyUse(keyUse)
                     .algorithm(keyAlg)
-                    .keyID(kid)
+                    .keyID(keyIdGenerator.generate(keyUse, kp.getPublic().getEncoded()))
                     .build();
 
             return rsaKey;


### PR DESCRIPTION
We have a need to use a key id claim of a specific format, this PR includes the changes to support this in a way which allows the addition of other generation methods as required.

The advantage of using a KeyId which is calculated from the public key is that a consumer who has only the key can figure out which key to use when a token is received.

Would you consider merging this PR? I would prefer not to have to maintain a fork but will do so if necessary.

Regards,
bruce
