### PR TITLE
Use latest Java LTS version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <java.version>11</java.version>
 	</properties>
 
 	<scm>
@@ -45,8 +46,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>14</source>
-					<target>14</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
IMHO tools and libraries should use the latest LTS version of java and not the bleeding edge that is only valid for 6 months.  
Unless there is a new algorithm that is only supported in newer versions..