### PR TITLE
feat: add Dockerfile for the json-web-key-generator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.8.6-openjdk-11 AS builder
+RUN mkdir ~/build
+COPY . /build
+WORKDIR /build
+RUN mvn package
+CMD ["java -jar ~/build/target/json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar -t"]
+
+FROM openjdk:11-jre-slim
+COPY --from=0 /build/target/json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar ./json-web-key-generator.jar
+ENTRYPOINT ["java", "-jar", "json-web-key-generator.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
+
+# Get the builder image
 FROM maven:3.8.6-openjdk-11 AS builder
-RUN mkdir ~/build
 COPY . /build
 WORKDIR /build
+# Build the app
+# Artifact will be stored at /build/target/json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar
 RUN mvn package
-CMD ["java -jar ~/build/target/json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar -t"]
 
+# Build the image with the new .jar binary
+# We need a jre 11+ starter container for this
 FROM openjdk:11-jre-slim
+ARG GIT_COMMIT=unspecified
+ARG GIT_TAG=unspecified
+LABEL org.opencontainers.image.authors="Besmir Zanaj"
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
+LABEL org.opencontainers.image.version="$GIT_TAG"
 COPY --from=0 /build/target/json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar ./json-web-key-generator.jar
 ENTRYPOINT ["java", "-jar", "json-web-key-generator.jar"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example:
 ```bash
 # Optional TAG
 #TAG="your/tag:here"
-# Example: TAG="beszan/json-web-key-generator:latest"
+# Example: TAG="<your_docker_id>/json-web-key-generator:latest"
 $ docker build -t $TAG .
 ```
 
@@ -58,17 +58,19 @@ in the docker image label.
 ```bash
 TAG=$(git describe --abbrev=0 --tags)
 REV=$(git log -1 --format=%h)
-docker build -t beszan/json-web-key-generator:$TAG --build-arg GIT_COMMIT=$REV --build-arg GIT_TAG=$TAG .
-docker push beszan/json-web-key-generator:$TAG
+docker build -t <your_docker_id>/json-web-key-generator:$TAG --build-arg GIT_COMMIT=$REV --build-arg GIT_TAG=$TAG .
+docker push <your_docker_id>/json-web-key-generator:$TAG
 
 # or push all the tags
-docker push beszan/json-web-key-generator --all-tags
+docker push <your_docker_id>/json-web-key-generator --all-tags
 ```
 
 ### Run from docker
 
+Example of running the app  within a docker container to generate a 2048 bit RSA JWK.
+
 ```bash
-$ docker run beszan/json-web-key-generator:latest -t RSA -s 2048
+$ docker run --rm <your_docker_id>/json-web-key-generator:latest -t RSA -s 2048
 Full key:
 {
   "p": "7blCsqibq1iTDOTxpLU9T5WEy5DgbwB65fXFEeU2y58mNUjXBFhDWppuEpJ7iMJtMsOhB60Mmf8ujRNVp8KmVT9eF6MwO7tW7sprq45YncwC8pZIpMqDdKOvB9moHVW9FzPlZimUzJsfgPAQc73SrpOSqwGHvPxfjvfO-kM_7wc",

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-json-web-key-generator
-======================
+# json-web-key-generator
 
 A commandline Java-based generator for JSON Web Keys (JWK) and JSON Private/Shared Keys (JPSKs).
 
-=====================
+## Standalone run
 
 To compile, run `mvn package`. This will generate a `json-web-key-generator-0.9-SNAPSHOT-jar-with-dependencies.jar` in the `/target` directory.
 
@@ -38,4 +37,34 @@ usage: java -jar json-web-key-generator.jar -t <keyType> [options]
                            will not be displayed to console. '-o/--output'
                            must be declared as well.
  -x,--x509                 Display keys in X509 PEM format
+```
+
+## Docker
+
+### Build with docker 
+Example:
+
+
+```bash
+TAG="your/tag:here"
+$ docker build -t $TAG .
+```
+
+### Run from docker
+
+```
+$ docker run beszan/json-web-key-generator:latest -t RSA -s 2048
+Full key:
+{
+  "p": "7blCsqibq1iTDOTxpLU9T5WEy5DgbwB65fXFEeU2y58mNUjXBFhDWppuEpJ7iMJtMsOhB60Mmf8ujRNVp8KmVT9eF6MwO7tW7sprq45YncwC8pZIpMqDdKOvB9moHVW9FzPlZimUzJsfgPAQc73SrpOSqwGHvPxfjvfO-kM_7wc",
+  "kty": "RSA",
+  "q": "uTMQv72suZzTkQg78MlDDNjYSjl_jRrok9pME_j4L94bEpqwftCLAHo9YCDHmMREcJa5X4UCIeG2bAqPx4izluaRQ3mktISMXtnPvLYUkooeWrQtrD7rYwurJeh0n_y_0YMVfH0OUUXxOOu6hljBXoxDhoqzPysJOljDEordNoc",
+  "d": "S14hFH5Ri0DrZqY4bArM8ryEjxv35kSLU6sixiCjHkCH0ZW9_tYEINDD9DRhggQtGfpuPsfIPQ0AWX9LmtKnIrOVmscrI_E8dkPvbTPAf_GePFSQaqtYobr4mjdhWHXStRGqSQnRnRpqbjcjs3wRyV42CTgJf8tBM1vTx_Pak5NYCpHWBu9vnN-Pzd60gpPxRZe-HaJbGRMVTNw11Rys--7Vcq-k6iyhYYBQiL3c62zNW6GzucmXxbSs8gQduPArvCKUAbJoMhWdCDvO3JIQTxccUdACs7xe9RDxucMHKbLM0yWUEbL6mS0J93-SypwNvUKbOkrGuc4sybmr2b1X5Q",
+  "e": "AQAB",
+  "kid": "1655476144",
+  "qi": "QMyZMfoUzearQ37ssHP5iB9FHDtZsTkq2Qr_76xMidgk5MJyEwJT90tAK3cC2x_tBRYKKrT9GXQYSHHNX0govfUGzwmlyK0GxX92C_Tr0BQZQzt2JP4BUnBk35REMPTv6aP1ODZ3u7d1_bvIY0bwZSDTVGirIdGYXRwf8XQdYQQ",
+  "dp": "J5_1yinoqMr-1-thi_7Z1WYq2HOxtU7zLVmmG7GFTLOefstBa-v6biPHrTjVdppR8WBCezERJKowbDuIz4nWh-ckG_SLmalEeFEtWU9E3iifZSg_u5g2CT8vcbOKHjmoZzGzTzAnKWPCAJADbgd6ErdufyqmIY4_r2kHCxgilAk",
+  "dq": "c6HNqFouOSoQ8rH4cuvGwIO38Agceqa9ZmtbKvE9TO3Za3FIF7XvxBmOrrFozhplPQLutRQf87WxJ54kjYntz58gPcf6rXdBCYvnZ8Ur7R7tuuZayfvzDkFf1-hewPGXdqHozXRrdxU7erW8HVvXSEg9dQiuyBb_yP1YtwAbBIs",
+  "n": "q_pMqQb2Lr7k1lOm_mXIBSWrn322vAWcnkBk1sVDZtR-n7keDVEOvby_LpM-7Dx-8fUTAU99RD4e4VgHb02bqmuodNfKjDXN9MFBmnhBkFWxxq0xXTj1e6IlQCGeAV2AnlcBmgzXTQ5a8IOBtBwbLkBUx1IbbwpJM6l2LhQmG756SxUjmDy9mHjQp_h0dr3u3TyceXR3GyG3cGeYfMYwaccZpGEQyCVRu1iwIahP6eoqIGGd_8V2W2vR5TU7yN4xiEdU8nGSVYcdGR7Cu22GxT0UXFYbu5o0A2LnLghjxHirw89WMm81ROaBOl5DdJzXyix2EE7snUBunJiyEi2GsQ"
+}
 ```

--- a/README.md
+++ b/README.md
@@ -46,13 +46,28 @@ Example:
 
 
 ```bash
-TAG="your/tag:here"
+# Optional TAG
+#TAG="your/tag:here"
+# Example: TAG="beszan/json-web-key-generator:latest"
 $ docker build -t $TAG .
+```
+
+If building from git tags then run the following to store the *tag*, and the *commit*
+in the docker image label.
+
+```bash
+TAG=$(git describe --abbrev=0 --tags)
+REV=$(git log -1 --format=%h)
+docker build -t beszan/json-web-key-generator:$TAG --build-arg GIT_COMMIT=$REV --build-arg GIT_TAG=$TAG .
+docker push beszan/json-web-key-generator:$TAG
+
+# or push all the tags
+docker push beszan/json-web-key-generator --all-tags
 ```
 
 ### Run from docker
 
-```
+```bash
 $ docker run beszan/json-web-key-generator:latest -t RSA -s 2048
 Full key:
 {


### PR DESCRIPTION
This PR will make possible to run the software as a binary from a container image rather than downloading and compiling it locally.
