### PR TITLE
upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,13 +85,13 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>3.8.1</version>
+			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>nimbus-jose-jwt</artifactId>
-			<version>8.19</version>
+			<version>9.31</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
@@ -101,22 +101,22 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>18.0</version>
+			<version>31.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.6</version>
+			<version>2.8.9</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcprov-jdk15on</artifactId>
-			<version>1.66</version>
+			<version>1.67</version>
 		</dependency>
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
 			<artifactId>bcpkix-jdk15on</artifactId>
-			<version>1.66</version>
+			<version>1.67</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/org/mitre/jose/jwk/Launcher.java
+++ b/src/main/java/org/mitre/jose/jwk/Launcher.java
@@ -407,8 +407,8 @@ public class Launcher {
 			List<JWK> jwkList = new ArrayList<>(existingKeys);
 			jwkList.add(jwk);
 			JWKSet jwkSet = new JWKSet(jwkList);
-			json = JsonParser.parseString(jwkSet.toJSONObject(false).toJSONString());
-			pubJson = JsonParser.parseString(jwkSet.toJSONObject(true).toJSONString());
+			json = JsonParser.parseString(jwkSet.toString(false));
+			pubJson = JsonParser.parseString(jwkSet.toString(true));
 		} else {
 			json = JsonParser.parseString(jwk.toJSONString());
 			pubJson = JsonParser.parseString(jwk.toPublicJWK().toJSONString());
@@ -427,7 +427,7 @@ public class Launcher {
 	private static void printKey(boolean keySet, JWK jwk, Gson gson) {
 		if (keySet) {
 			JWKSet jwkSet = new JWKSet(jwk);
-			JsonElement json = JsonParser.parseString(jwkSet.toJSONObject(false).toJSONString());
+			JsonElement json = JsonParser.parseString(jwkSet.toString(false));
 			System.out.println(gson.toJson(json));
 		} else {
 			JsonElement json = JsonParser.parseString(jwk.toJSONString());


### PR DESCRIPTION
Dependencies upgraded to latest versions.

 - junit 3.8.1 -> 4.13.2
 - nimbus-jose-jwt 8.19 -> 9.13
 - guava 18.0 -> 31.1-jre

Our CVE scanner was complaining of:

CVE-2022-25647 (HIGH) for com.google.code.gson:gson com.google.code.gson-gson: Deserialization of Untrusted Data in com.google.code.gson-gson: (https://avd.aquasec.com/nvd/cve-2022-25647)
    The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks.
-----

-----
CVE-2021-31684 (HIGH) for net.minidev:json-smart json-smart: Denial of Service in JSONParserByteArray function: (https://avd.aquasec.com/nvd/cve-2021-31684)
    A vulnerability was discovered in the indexOf function of JSONParserByteArray in JSON Smart versions 1.3 and 2.4 which causes a denial of service (DOS) via a crafted web request.
-----